### PR TITLE
update README with SDL2_net dependency

### DIFF
--- a/compilation.md
+++ b/compilation.md
@@ -81,6 +81,7 @@ The following libraries are required to compile and execute Solarus:
 - SDL2main
 - SDL2_image
 - SDL2_ttf
+- SDL2_net
 - OpenGL or OpenGL ES
 - OpenAL
 - Vorbisfile
@@ -130,7 +131,7 @@ Just install the corresponding packages.
 For example, in Ubuntu or Debian:
 
     build-essential cmake pkg-config
-    libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libluajit-5.1-dev
+    libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libsdl2-net-dev libluajit-5.1-dev
     libphysfs-dev libopenal-dev libvorbis-dev libmodplug-dev
     qtbase5-dev qttools5-dev qttools5-dev-tools libglm-dev
 


### PR DESCRIPTION
To be able to compile solarus correctly, I had to install all the required dependencies, plus SDL2_net.

This PR adds this dependency to the list of required dependencies to the `compilation.md` file